### PR TITLE
Bugfix/create init user #109

### DIFF
--- a/init.js
+++ b/init.js
@@ -133,7 +133,7 @@ Meteor.startup(() => {
 Meteor.startup(() => {
 
   if (Meteor.isServer) {
-    if (!Meteor.users.findOne()) {
+    if (!Meteor.users.findOne({ roles: 'admin' })) {
       const { admin } = Meteor.settings.credentials;
       admin.profile = {
         name: 'Lern Admin',

--- a/init.js
+++ b/init.js
@@ -99,7 +99,9 @@ Meteor.startup(() => {
       `você estar conosco nessa jornada.</p>` +
       `<p>Nós, da Lern - Soluções Educaionais, queremos ajudá-lo ao ` +
       `máximo com suas habilidades e desenvolvimento pessoal.</p>` +
-      `<p>Para isso, precisamos que acesse eonda por esse e-mail. ` +
+      `<p>Para isso, precisamos que acesse esse ` +
+      `<a href='${url}'>link de verificação</a> e finalize o seu cadastro.</p>` +
+      `<p>Se ainda resta alguma dúvida, responda por esse e-mail. ` +
       `<br>` +
       `<br>` +
       `<p>Caso você ou sua escola não tenham se registrado, ignore esta mensagem.</p>` +

--- a/server/hooks/login.js
+++ b/server/hooks/login.js
@@ -32,7 +32,11 @@ Meteor.startup(() => {
           user.emails = [{ address: _.get(google, 'email'), verified: true }];
         else
           user.emails = [];
-      } else if (options.profile) user.profile = options.profile;
+      } else if (options.profile) {
+        user.profile = options.profile;
+        if (options.email)
+          user.emails = [{ address: options.email, verified: false }];
+      }
 
       if (!user.roles) user.roles = ['student'];
 


### PR DESCRIPTION
Corrigi o problema segundo as recomendações de @andredornas. 
Criei um `if (options.email)` dentro de `if (options.profile)`. Não alterei o settings.json pois a função `Accounts.createUser()` solicita um objeto com as keys email e password em forma de string.

Agora o settings.json será sempre da forma abaixo:
```json
"credentials": {
    "admin" : {
      "email" : "root@root.com",
      "password" : "..."
    }
}
```